### PR TITLE
Resolving deprecation warning

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,4 +7,4 @@
     owner: root
     group: root
     mode: "0644"
-  with_items: logrotate_scripts
+  with_items: "{{ logrotate_scripts }}"


### PR DESCRIPTION
```
TASK [franklinkim.logrotate : Configuring logrotate] ***************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{logrotate_scripts}}').
This feature
 will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Future-proofing the role against the upcoming deprecation of **bare variable** use playbooks.
